### PR TITLE
Update MacOS lease file detection

### DIFF
--- a/go_src/vagrant-vmware-utility/driver/core.go
+++ b/go_src/vagrant-vmware-utility/driver/core.go
@@ -158,6 +158,17 @@ func CreateDriver(vmxPath *string, b *BaseDriver, logger hclog.Logger) (Driver, 
 			logger.Error("failed to get VMware information", "error", err)
 			return d, err
 		}
+
+		// Assume advanced driver for experimental builds
+		if info.Version == "e.x.p" {
+			logger.Debug("creating new advanced driver")
+			d, err = NewAdvancedDriver(vmxPath, b, logger)
+			if err != nil {
+				return d, err
+			}
+			return d, nil
+		}
+
 		verParts := strings.Split(info.Version, ".")
 		if len(verParts) < 1 {
 			logger.Warn("failed to determine major version, using simple driver",

--- a/go_src/vagrant-vmware-utility/utility/vmware_paths_darwin.go
+++ b/go_src/vagrant-vmware-utility/utility/vmware_paths_darwin.go
@@ -2,8 +2,11 @@ package utility
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 func (v *VmwarePaths) Load() error {
@@ -14,19 +17,6 @@ func (v *VmwarePaths) Load() error {
 	}
 	v.BridgePid = "/var/run/vmnet-bridge.pid"
 	v.Networking = "/Library/Preferences/VMware Fusion/networking"
-	// Starting on Big Sur, VMware is using the native vmnet framework instead
-	// of their internal tools. This means that the dhcpd being used is also
-	// provided by the platform and not VMware internal tools
-	darwin, err := GetDarwinMajor()
-	if err != nil {
-		// Assume non-Big Sur by default
-		darwin = 19
-	}
-	if darwin >= 20 {
-		v.DhcpLease = "/var/db/dhcpd_leases"
-	} else {
-		v.DhcpLease = "/var/db/vmware/vmnet-dhcpd-{{device}}.leases"
-	}
 	v.NatConf = "/Library/Preferences/VMware Fusion/{{device}}/nat.conf"
 	v.VmnetCli = filepath.Join(v.InstallDir, "Contents/Library/vmnet-cli")
 	v.Vnetlib = filepath.Join(v.InstallDir, "Contents/Library/vmnet-cfgcli")
@@ -35,5 +25,45 @@ func (v *VmwarePaths) Load() error {
 	v.Vmx = filepath.Join(v.InstallDir, "Contents/Library/vmware-vmx")
 	v.Vmrest = filepath.Join(v.InstallDir, "Contents/Library/vmrest")
 	v.Vdiskmanager = filepath.Join(v.InstallDir, "Contents/Library/vmware-vdiskmanager")
+	return nil
+}
+
+func (v *VmwarePaths) UpdateVmwareDhcpLeasePath(version string) error {
+	// default to using VMware dhcp lease file
+	v.DhcpLease = "/var/db/vmware/vmnet-dhcpd-{{device}}.leases"
+
+	// In Big Sur, VMware started using the native vmnet framework instead
+	// of their internal tools. This means that the dhcpd being used is also
+	// provided by the platform and not VMware internal tools.
+	// However, issues with transiting VPNs required migrating back to the
+	// VMware DHCP implementation.
+
+	// New experimental pre-releases use VMware DHCP
+	if version == "e.x.p" {
+		return nil
+	}
+
+	darwin, err := GetDarwinMajor()
+	if darwin != 20 {
+		return nil
+	}
+
+	// Big Sur and Fusion 12.0 or 12.1 used the native framework
+	verParts := strings.Split(version, ".")
+	if len(verParts) < 2 {
+		return errors.New("Invalid version string")
+	}
+	major, err := strconv.Atoi(verParts[0])
+	if err != nil {
+		return fmt.Errorf("Invalid major version number: %s", verParts[0])
+	}
+	minor, err := strconv.Atoi(verParts[1])
+	if err != nil {
+		return fmt.Errorf("Invalid minor version number: %s", verParts[1])
+	}
+	if major == 12 && (minor == 0 || minor == 1) {
+		v.DhcpLease = "/var/db/dhcpd_leases"
+	}
+
 	return nil
 }

--- a/go_src/vagrant-vmware-utility/utility/vmware_paths_linux.go
+++ b/go_src/vagrant-vmware-utility/utility/vmware_paths_linux.go
@@ -37,3 +37,7 @@ func (v *VmwarePaths) Load() (err error) {
 	v.Vmrest = "/bin/false"
 	return
 }
+
+func (v *VmwarePaths) UpdateVmwareDhcpLeasePath(version string) error {
+	return nil
+}

--- a/go_src/vagrant-vmware-utility/utility/vmware_paths_windows.go
+++ b/go_src/vagrant-vmware-utility/utility/vmware_paths_windows.go
@@ -66,3 +66,7 @@ func (v *VmwarePaths) Load() error {
 
 	return nil
 }
+
+func (v *VmwarePaths) UpdateVmwareDhcpLeasePath(version string) error {
+	return nil
+}


### PR DESCRIPTION
Fusion version 12 on Big Sur started using the Apple native vmnet framework.
However, issues with transiting VPNs is requiring VMware to move back to the
VMware DHCP implementation.

Changes:
- Use Apple networking with Big Sur and Fusion versions 12.0 and 12.1
- Switch back to using VMware networking in Fusion version 12.2+
- All other cases will use VMware networking
- Additionally, handle pre-release "experimental" builds that show a
  build number of "e.x.p" with VMware networking

Signed-off-by: Mark Peek <markpeek@vmware.com>