### PR TITLE
Fix synced folder name with Windows paths

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -398,7 +398,11 @@ module HashiCorp
         # This deletes the VM.
         def delete
           @logger.info("Deleting VM: #{@vm_dir}")
-          @vm_dir.rmtree
+          begin
+            @vm_dir.rmtree
+          rescue Errno::ENOTEMPTY
+            FileUtils.rm_rf(@vm_dir.to_s)
+          end
         end
 
         # This discards the suspended state of the machine.

--- a/lib/vagrant-vmware-desktop/synced_folder.rb
+++ b/lib/vagrant-vmware-desktop/synced_folder.rb
@@ -54,7 +54,7 @@ module HashiCorp
         machine.ui.info I18n.t("hashicorp.vagrant_vmware_desktop.sharing_folders")
         machine.provider.driver.enable_shared_folders
         shared_folders.each do |id, data|
-          id        = id.gsub('/', machine.provider_config.shared_folder_special_char)
+          id        = id.gsub(%r{[:\\/]}, machine.provider_config.shared_folder_special_char)
           path      = data[:hostpath]
           guestpath = data[:guestpath]
 


### PR DESCRIPTION
Removes more special characters from the guest path when
creating the synced folder named used for sharing within
the guest. This prevents encoded characters from being
introduced into the name and breaking the generated link.

Fixes #9
