### PR TITLE
Increase soft limit for max open files

### DIFF
--- a/go_src/vagrant-vmware-utility/command/service_darwin.go
+++ b/go_src/vagrant-vmware-utility/command/service_darwin.go
@@ -53,6 +53,15 @@ const LAUNCHD_JOB = `<?xml version="1.0" encoding="UTF-8"?>
         <string>%s</string>
     <key>AbandonProcessGroup</key>
         <true/>
+	  <!--
+	    default is 256 which can be low if we are handling port
+	    forwarding so increase to a reasonably larger amount
+	  -->
+	  <key>SoftResourceLimits</key>
+	  <dict>
+	      <key>NumberOfFiles</key>
+	      <integer>4096</integer>
+	  </dict>
 </dict>
 </plist>
 `


### PR DESCRIPTION
When handling port forwarding internally, a large number of port forwards
can exhaust the some what limited default max open files setting of 256.
This updates the soft limit to 4096 to prevent reaching the max so easily.

Fixes #15
