### PR TITLE
Fix missing args with "vmrun"

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -1230,6 +1230,16 @@ module HashiCorp
 
         # This executes the "vmrun" command with the given arguments.
         def vmrun(*command)
+          # Get the VMware product family
+          host_type = "player" # default, plugin is not support "vmplayer".
+          case PRODUCT_NAME.to_s
+          when "workstation" then
+            host_type = "ws"
+          when "fusion"
+            host_type = "fusion"
+          end
+           
+          # Execute the "vmrun" with host_type parameters
           begin
             vmexec(@vmrun_path, *command)
           rescue Errors::VMExecError => e

--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -1241,7 +1241,7 @@ module HashiCorp
            
           # Execute the "vmrun" with host_type parameters
           begin
-            vmexec(@vmrun_path, *command)
+            vmexec(@vmrun_path, "-T", host_type, *command)
           rescue Errors::VMExecError => e
             raise Errors::VMRunError,
               :command => e.extra_data[:command],


### PR DESCRIPTION
The VMware Workstation Pro for Linux Installer is installing Workstation Pro and Player. 
Probably the default of `vmrun` command in Linux is the `player`.
So, Add "-T {host_type}" arguments when executing the `vmrun` command.

I tested ` vagrant init "generic/ubuntu2010" && vagrant up` on below environment.
- ArchLinux & VMware Workstation 16 Pro 16.2.1
- macOS Big Sur 11.5.2 & VMware Fusion Pro 12.2.1
- Windows 10 Enterprise 21H1 & Workstation 16 Pro 16.0.0

related: #31 #34 