### PR TITLE
Include product type within `vmrun` commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,18 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5.x', '2.6.x', '2.7.x' ]
+        ruby: [ '3.0', '3.1', '3.2' ]
     name: Vagrant VMware Plugin unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
-          architecture: 'x64'
+          bundler-cache: true
       - name: Run Tests
         run: .ci/test.sh


### PR DESCRIPTION
Determine the correct product type based on product name and the license
in use. Include the product type when executing the `vmrun` commands.

Fixes #31 #32
