### PR TITLE
Enable builds for macOS packages

### DIFF
--- a/.ci/.ci-utility-files/common.sh
+++ b/.ci/.ci-utility-files/common.sh
@@ -585,7 +585,6 @@ function sign_file() {
 
     local binary_identifier=""
     local entitlements=""
-    local input_file="${1}"
     local output_file=""
 
     local opt
@@ -596,8 +595,10 @@ function sign_file() {
             "o") output_file="${OPTARG}" ;;
             *) failure "Invalid flag provided" ;;
         esac
-        shift $((OPTIND-1))
     done
+    shift $((OPTIND-1))
+
+    local input_file="${1}"
 
     # Check that a good input file was given
     if [ -z "${input_file}" ]; then

--- a/.ci/build-macos-dmg
+++ b/.ci/build-macos-dmg
@@ -50,9 +50,9 @@ chmod +x "${dmgdir}/uninstall.tool" ||
     fail "Failed to modify permissions on uninstall tool in dmg staging directory"
 
 # Lets build our DMG
-dmgbuild -s "${root}/macos/dmgbuild.py" \
+dmgbuild -s "${root}/package/macos/dmgbuild.py" \
     -D srcfolder="${dmgdir}" \
-    -D backgroundimg="${root}/macos/background_installer.png" \
+    -D backgroundimg="${root}/package/macos/background_installer.png" \
     "Vagrant VMware Utility" \
     "${output_path}" ||
     fail "Failed to build DMG"

--- a/.ci/create-cache
+++ b/.ci/create-cache
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# This script is used for caching artifacts for later
+# reuse. It does this using a draft release (used for
+# flexibility/compatibility) to store the artifact for
+# later retrieval.
+
 csource="${BASH_SOURCE[0]}"
 while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
 root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
@@ -23,9 +28,9 @@ if [ ! -e "${source}" ]; then
     failure "source path provided for cache does not exist (${source})"
 fi
 
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${cache_name}"; then
+if github_draft_release_exists "${repo_name}" "${cache_name}"; then
     printf "Cache item already exists (name: %s repository: %s)" "${cache_name}" "${repo_owner}/${repo_name}" >&2
     exit 1
 fi
 
-github_draft_release "${repo_owner}" "${repo_name}" "${cache_name}" "${source}"
+github_draft_release "${repo_name}" "${cache_name}" "${source}"

--- a/.ci/notarize-file
+++ b/.ci/notarize-file
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+
+# Check for required environment variable
+if [ -z "${NOTARIZE_KEY}" ]; then
+    failure "NOTARIZATION_KEY environment variable is required"
+fi
+
+# Validate an input file was provided
+input_file="${1}"
+if [ -z "${input_file}" ]; then
+    failure "Input file is required for notarization"
+fi
+if [ ! -f "${input_file}" ]; then
+    failure "Invalid input file given for notarization (%s)" "${input_file}"
+fi
+
+# Create a file to store the key contents
+key_file="$(mktemp)" ||
+    failure "Failed to create key file"
+chmod 0600 "${key_file}" ||
+    failure "Failed to modify key file permissions"
+
+# Add a cleanup to delete the key file
+function cleanup() {
+    if [ -n "${key_file}" ] && [ -f "${key_file}" ]; then
+        rm -f "${key_file}"
+    fi
+}
+
+# Write the key contents
+printf "%s" "${NOTARIZE_KEY}" > "${key_file}"
+
+# Now notarize the file
+notarize_file -m 3600 -j "${key_file}" "${input_file}"

--- a/.ci/restore-cache
+++ b/.ci/restore-cache
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This script is used for fetching artifacts that
+# were previously cached. The cache store used is
+# a draft release (used for flexibility/compatibility)
+
 csource="${BASH_SOURCE[0]}"
 while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
 root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
@@ -30,4 +34,4 @@ mkdir -p "${destination}" || failure "Could not create destination directory (${
 pushd "${destination}"
 
 # Now download all the artifacts within the draft release
-github_draft_release_assets "${repo_owner}" "${repo_name}" "${cache_name}"
+github_draft_release_assets "${repo_name}" "${cache_name}"

--- a/.ci/utility-binaries-prerelease
+++ b/.ci/utility-binaries-prerelease
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Output to stdout if we aren't on a runner
+if [ -z "${GITHUB_OUTPUT}" ]; then
+    GITHUB_OUTPUT="/dev/stdout"
+fi
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+pushd "${root}"
+
+release_name="${1}"
+if [ -z "${release_name}" ]; then
+    failure "Name is required for utility binaries release"
+fi
+
+info "Building vagrant-vmware-utility binaries..."
+
+# Build binaries
+make all ||
+    failure "Failed to build utilities"
+
+info "Publishing utility binaries prerelease..."
+
+if [ -n "${IS_NIGHTLY}" ]; then
+    body="Vagrant VMware Utility binaries nightly build"
+else
+    body="Vagrant VMware Utility binaries custom build (branch: ${ident_ref})"
+fi
+
+release_output="$(github_create_release -o "${repo_owner}" -r "${repo_name}" -n "${release_name}" -t "${release_name}" -c "${full_sha}" -b "${body}" -p -m)" ||
+    failure "Could not create GitHub prerelease"
+debug "new release created: %s" "${release_output}"
+release_id="$(printf "%s" "${release_output}" | jq -r '.id')" ||
+    failure "Could not get release ID from release creation response"
+
+# Upload release artifacts
+debug "uploading artifacts for vagrant vmware utility binaries release '%s' (ID: %d)" "${nightly_name}" "${release_id}"
+github_upload_release_artifacts "${repo_name}" "${release_id}" ./bin

--- a/.ci/utility-bins-information
+++ b/.ci/utility-bins-information
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Output to stdout if we aren't on a runner
+if [ -z "${GITHUB_OUTPUT}" ]; then
+    GITHUB_OUTPUT="/dev/stdout"
+fi
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+pushd "${root}"
+
+version="$(<go_src/vagrant-vmware-utility/version/version.go)"
+version="${version##*VERSION = \"}"
+version="${version%%\"*}"
+util_id="$(git log --format=%h -1 ./go_src)" ||
+    failure "Could not generate commit sha for ./go_src"
+
+util_version="${version}+bins-${util_id}"
+
+printf "utility-version: %s\n" "${version}"
+printf "utility-bins-version: %s\n" "${util_version}"
+
+if github_release_exists "${repo_name}" "${util_version}"; then
+    printf "utility-bins-release-exists: true\n"
+fi

--- a/.ci/utility-information
+++ b/.ci/utility-information
@@ -28,45 +28,45 @@ windows_id="utility-${util_id}-windows"
 # if the cache currently exists
 
 # Define the utility version
-printf "utility-version=%s\n" "${version}"
+debug "utility-version=%s" "${version}"
 printf "utility-version=%s\n" "${version}" >> "${GITHUB_OUTPUT}"
 
 # Set unsigned cache identifer and check existence
-printf "unsigned-cache-id=%s\n" "${unsigned_id}"
+debug "unsigned-cache-id=%s" "${unsigned_id}"
 printf "unsigned-cache-id=%s\n" "${unsigned_id}" >> "${GITHUB_OUTPUT}"
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${unsigned_id}"; then
-    printf "unsigned-cache-exists=true\n"
+if github_draft_release_exists "${repo_name}" "${unsigned_id}"; then
+    debug "unsigned-cache-exists=true"
     printf "unsigned-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
 # Set signed cache identifer and check existence
-printf "signed-cache-id=%s\n" "${signed_id}"
+debug "signed-cache-id=%s" "${signed_id}"
 printf "signed-cache-id=%s\n" "${signed_id}" >> "${GITHUB_OUTPUT}"
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${signed_id}"; then
-    printf "signed-cache-exists=true\n"
+if github_draft_release_exists "${repo_name}" "${signed_id}"; then
+    debug "signed-cache-exists=true"
     printf "signed-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
 # Set linux cache identifer and check existence
-printf "linux-cache-id=%s\n" "${linux_id}"
+debug "linux-cache-id=%s" "${linux_id}"
 printf "linux-cache-id=%s\n" "${linux_id}" >> "${GITHUB_OUTPUT}"
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${linux_id}"; then
-    printf "linux-cache-exists=true\n"
+if github_draft_release_exists "${repo_name}" "${linux_id}"; then
+    debug "linux-cache-exists=true"
     printf "linux-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
 # Set macos cache identifer and check existence
-printf "macos-cache-id=%s\n" "${macos_id}"
+debug "macos-cache-id=%s" "${macos_id}"
 printf "macos-cache-id=%s\n" "${macos_id}" >> "${GITHUB_OUTPUT}"
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${macos_id}"; then
-    printf "macos-cache-exists=true\n"
+if github_draft_release_exists "${repo_name}" "${macos_id}"; then
+    debug "macos-cache-exists=true"
     printf "macos-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi
 
 # Set windows cache identifer and check existence
-printf "windows-cache-id=%s\n" "${windows_id}"
+debug "windows-cache-id=%s" "${windows_id}"
 printf "windows-cache-id=%s\n" "${windows_id}" >> "${GITHUB_OUTPUT}"
-if github_draft_release_exists "${repo_owner}" "${repo_name}" "${windows_id}"; then
-    printf "windows-cache-exists=true\n"
+if github_draft_release_exists "${repo_name}" "${windows_id}"; then
+    debug "windows-cache-exists=true"
     printf "windows-cache-exists=true\n" >> "${GITHUB_OUTPUT}"
 fi

--- a/.github/workflows/build-utility-packages.yml
+++ b/.github/workflows/build-utility-packages.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - 'build-utility-macos-*'
+      - 'build-utility-packages-*'
   workflow_call:
     outputs:
       linux-cache-id:

--- a/.github/workflows/build-utility-packages.yml
+++ b/.github/workflows/build-utility-packages.yml
@@ -101,11 +101,12 @@ jobs:
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
       - name: Sign Windows binary
-        run: ./.ci/sign-file "./bin/vagrant-vmware-utility.exe"
+        run: . .ci/load-ci.sh && sign_file "./bin/vagrant-vmware-utility.exe"
         env:
-          SIGNORE_WINDOWS: ${{ steps.secrets.outputs.signore_windows_signer }}
+          SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_windows_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
       - name: Cache signed binaries
         run: ./.ci/create-cache "${CACHE_ID}" ./bin
         env:
@@ -170,7 +171,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-macos-corepkg:
     if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
-    name: Build macOS package
+    name: Build macOS core package
     runs-on: macos-latest
     needs: [info, build]
     permissions:
@@ -184,6 +185,7 @@ jobs:
         run: ./.ci/restore-cache "${CACHE_ID}" ./bin
         env:
           CACHE_ID: ${{ needs.info.outputs.signed-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build core package
         id: build-core
         run: ./.ci/build-macos-core-pkg ./bin/vagrant-vmware-utility_darwin_universal
@@ -199,9 +201,10 @@ jobs:
           name: corepkg-unsigned
           path: ./corepkg
   sign-macos-corepkg:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
+    name: Sign macOS core package
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
-    needs: [build-macos-corepkg]
+    needs: [info, build-macos-corepkg]
     permissions:
       id-token: write
       contents: write
@@ -241,8 +244,8 @@ jobs:
           name: corepkg-signed
           path: ./corepkg
   build-macos-fullpkg:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
-    name: Build macOS package
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
+    name: Build macOS full package
     runs-on: macos-latest
     needs: [info, sign-macos-corepkg]
     steps:
@@ -250,6 +253,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Upgrade bash
         run: brew install bash
+      - name: Fetch binaries
+        run: ./.ci/restore-cache "${CACHE_ID}" ./bin
+        env:
+          CACHE_ID: ${{ needs.info.outputs.signed-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download signed core package
         uses: actions/download-artifact@v3
         with:
@@ -270,9 +278,10 @@ jobs:
           name: fullpkg-unsigned
           path: ./fullpkg
   sign-macos-fullpkg:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
+    name: Sign macOS full package
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
-    needs: [build-macos-corepkg]
+    needs: [info, build-macos-fullpkg]
     permissions:
       id-token: write
       contents: write
@@ -312,8 +321,8 @@ jobs:
           name: fullpkg-signed
           path: ./fullpkg
   build-macos-dmg:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
-    name: Build macOS package
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
+    name: Build macOS DMG
     runs-on: macos-latest
     needs: [info, sign-macos-fullpkg]
     steps:
@@ -341,9 +350,10 @@ jobs:
           name: dmg-unsigned
           path: ./dmg
   sign-and-notarize-macos-dmg:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
+    name: Sign macOS DMG
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
-    needs: [build-macos-dmg]
+    needs: [info, build-macos-dmg]
     permissions:
       id-token: write
       contents: write
@@ -386,6 +396,7 @@ jobs:
         run: ./.ci/create-cache "${CACHE_ID}" ./dmg
         env:
           CACHE_ID: ${{ needs.info.outputs.macos-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-windows:
     if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true'
     name: Build Windows package

--- a/.github/workflows/build-utility-packages.yml
+++ b/.github/workflows/build-utility-packages.yml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - 'build-utility-macos-*'
   workflow_call:
     outputs:
       linux-cache-id:
@@ -21,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions: # These need to be write for access to draft releases
       contents: write
-      packages: write
     outputs:
       utility-version: ${{ steps.inspect.outputs.utility-version }}
       unsigned-cache-id: ${{ steps.inspect.outputs.unsigned-cache-id }}
@@ -52,7 +54,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      packages: write
     steps:
       - name: Authentication
         id: vault-auth
@@ -92,20 +93,15 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.unsigned-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Signore
-        run: ./.ci/install-signore
-        env:
-          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
       - name: Sign macOS binary
-        run: |
-          ./.ci/sign-file -b "vagrant-vmware-utility" \
-            "./bin/vagrant-vmware-utility_darwin_universal" \
+        run: . .ci/load-ci.sh && sign_file -b "vagrant-vmware-utility" "./bin/vagrant-vmware-utility_darwin_universal"
         env:
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_macos_binary_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
       - name: Sign Windows binary
-        run: ./.ci/sign-file "./bin/vagrant-vmware-utility_darwin_universal"
+        run: ./.ci/sign-file "./bin/vagrant-vmware-utility.exe"
         env:
           SIGNORE_WINDOWS: ${{ steps.secrets.outputs.signore_windows_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
@@ -116,13 +112,12 @@ jobs:
           CACHE_ID: ${{ needs.info.outputs.signed-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows-binary:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true' && always()
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true' && !failure() && !cancelled()
     name: Store Windows binary
     runs-on: ubuntu-latest
     needs: [info, build]
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
@@ -137,13 +132,12 @@ jobs:
           name: windows-binary
           path: ./bin
   build-linux:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.linux-cache-exists != 'true' && always()
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.linux-cache-exists != 'true' && !failure() && !cancelled()
     name: Build Linux RPM, DEB, and PACMAN packages
     runs-on: ubuntu-latest
     needs: [info, build]
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
@@ -174,15 +168,43 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.linux-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-macos:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builde' && needs.info.outputs.macos-cache-exists != 'true' && always()
+  build-macos-corepkg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.macos-cache-exists != 'true'  && !failure() && !cancelled()
     name: Build macOS package
-    runs-on: ['self-hosted', 'ondemand', 'os=macos', 'x86']
+    runs-on: macos-latest
     needs: [info, build]
+    permissions:
+      contents: write
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Upgrade bash
+        run: brew install bash
+      - name: Fetch binaries
+        run: ./.ci/restore-cache "${CACHE_ID}" ./bin
+        env:
+          CACHE_ID: ${{ needs.info.outputs.signed-cache-id }}
+      - name: Build core package
+        id: build-core
+        run: ./.ci/build-macos-core-pkg ./bin/vagrant-vmware-utility_darwin_universal
+        env:
+          UTILITY_VERSION: ${{ needs.info.outputs.utility-version }}
+      - name: Relocate for upload
+        run: mkdir ./corepkg && mv "${CORE_PKG}" ./corepkg
+        env:
+          CORE_PKG: ${{ steps.build-core.outputs.core-path }}
+      - name: Upload core package
+        uses: actions/upload-artifact@v3
+        with:
+          name: corepkg-unsigned
+          path: ./corepkg
+  sign-macos-corepkg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    needs: [build-macos-corepkg]
     permissions:
       id-token: write
       contents: write
-      packages: write
     steps:
       - name: Authentication
         id: vault-auth
@@ -198,73 +220,174 @@ jobs:
             kv/data/teams/vagrant/hashibot signore_token;
             kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_id;
             kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_secret;
-            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_macos_binary_signer;
             kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_macos_installer_signer;
       - name: Code Checkout
         uses: actions/checkout@v3
-      - name: Fetch binaries
-        run: ./.ci/restore-cache "${CACHE_ID}" ./bin
-        env:
-          CACHE_ID: ${{ needs.info.outputs.signed-cache-id }}
-      - name: Install signore
-        run: ./.ci/install-signore
+      - name: Download unsigned core package
+        uses: actions/download-artifact@v3
+        with:
+          name: corepkg-unsigned
+          path: ./corepkg
+      - name: Sign core package
+        run: . .ci/load-ci.sh && sign_file ./corepkg/*
         env:
           HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
-      - name: Build core package
-        id: build-core
-        run: ./.ci/build-macos-core-pkg ./bin/vagrant-vmware-utility_darwin_universal
-        env:
-          UTILITY_VERSION: ${{ needs.info.outputs.utility-version }}
-      - name: Sign core package
-        run: ./.ci/sign-file "${PKG_PATH}"
-        env:
-          PKG_PATH: ${{ steps.build-core.outputs.core-path }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_macos_installer_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
+      - name: Upload signed core package
+        uses: actions/upload-artifact@v3
+        with:
+          name: corepkg-signed
+          path: ./corepkg
+  build-macos-fullpkg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    name: Build macOS package
+    runs-on: macos-latest
+    needs: [info, sign-macos-corepkg]
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Upgrade bash
+        run: brew install bash
+      - name: Download signed core package
+        uses: actions/download-artifact@v3
+        with:
+          name: corepkg-signed
+          path: ./corepkg
       - name: Build full package
         id: build-full
-        run: ./.ci/build-macos-full-pkg "${CORE_PKG}"
+        run: ./.ci/build-macos-full-pkg ./corepkg/*
         env:
-          CORE_PKG: ${{ steps.build-core.outputs.core-path }}
           UTILITY_VERSION: ${{ needs.info.outputs.utility-version }}
-      - name: Sign full package
-        run: ./.ci/sign-file "${PKG_PATH}"
+      - name: Relocate for upload
+        run: mkdir ./fullpkg && mv "${FULL_PKG}" ./fullpkg
         env:
-          PKG_PATH: ${{ steps.build-full.outputs.full-path }}
+          FULL_PKG: ${{ steps.build-full.outputs.full-path }}
+      - name: Upload full package
+        uses: actions/upload-artifact@v3
+        with:
+          name: fullpkg-unsigned
+          path: ./fullpkg
+  sign-macos-fullpkg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    needs: [build-macos-corepkg]
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_id;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_secret;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_macos_installer_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Download unsigned full package
+        uses: actions/download-artifact@v3
+        with:
+          name: fullpkg-unsigned
+          path: ./fullpkg
+      - name: Sign full package
+        run: . .ci/load-ci.sh && sign_file ./fullpkg/*
+        env:
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_macos_installer_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
+      - name: Upload signed full package
+        uses: actions/upload-artifact@v3
+        with:
+          name: fullpkg-signed
+          path: ./fullpkg
+  build-macos-dmg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    name: Build macOS package
+    runs-on: macos-latest
+    needs: [info, sign-macos-fullpkg]
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Upgrade bash
+        run: brew install bash
+      - name: Download signed full package
+        uses: actions/download-artifact@v3
+        with:
+          name: fullpkg-signed
+          path: ./fullpkg
       - name: Build DMG
         id: build-dmg
-        run: ./.ci/build-macos-dmg "${FULL_PKG}"
+        run: ./.ci/build-macos-dmg ./fullpkg/*
         env:
-          FULL_PKG: ${{ steps.build-full.outputs.full-path }}
           UTILITY_VERSION: ${{ needs.info.outputs.utility-version }}
-      - name: Sign DMG
-        run: ./.ci/sign-file "${DMG_PATH}"
+      - name: Relocate for upload
+        run: mkdir ./dmg && mv "${DMG}" ./dmg
         env:
-          DMG_PATH: ${{ steps.outputs.build-dmg.dmg-path }}
+          DMG: ${{ steps.build-dmg.outputs.dmg-path }}
+      - name: Upload DMG
+        uses: actions/upload-artifact@v3
+        with:
+          name: dmg-unsigned
+          path: ./dmg
+  sign-and-notarize-macos-dmg:
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder'
+    runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
+    needs: [build-macos-dmg]
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Authentication
+        id: vault-auth
+        run: vault-auth
+      - name: Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ steps.vault-auth.outputs.addr }}
+          caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+          token: ${{ steps.vault-auth.outputs.token }}
+          secrets:
+            kv/data/teams/vagrant/hashibot signore_token;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder notarization_key;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_id;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_client_secret;
+            kv/data/github/hashicorp/vagrant-vmware-desktop-builder signore_macos_binary_signer;
+      - name: Code Checkout
+        uses: actions/checkout@v3
+      - name: Download unsigned DMG
+        uses: actions/download-artifact@v3
+        with:
+          name: dmg-unsigned
+          path: ./dmg
+      - name: Sign DMG
+        run: . .ci/load-ci.sh && sign_file ./dmg/*
+        env:
+          HASHIBOT_TOKEN: ${{ steps.secrets.outputs.signore_token }}
           SIGNORE_SIGNER: ${{ steps.secrets.outputs.signore_macos_binary_signer }}
           SIGNORE_CLIENT_ID: ${{ steps.secrets.outputs.signore_client_id  }}
           SIGNORE_CLIENT_SECRET: ${{ steps.secrets.outputs.signore_client_secret }}
       - name: Notarize DMG
-        run: ./.ci/notarize "${BUNDLE_ID}" "${DMG_PATH}"
+        run: ./.ci/notarize-file ./dmg/*.dmg
         env:
-          BUNDLE_ID: com.vagrant.vagrant-vmware-utility
-          DMG_PATH: ${{ steps.build-dmg.outputs.dmg-path }}
-          AC_USERNAME: ${{ steps.secrets.outputs.notarization_username }}
-          AC_PASSWORD: ${{ steps.secrets.outputs.notarization_password }}
-      - name: Relocate DMG for caching
-        run: mkdir -p ./pkg && mv "${DMG_PATH}" ./pkg
-        env:
-          DMG_PATH: ${{ steps.build-dmg.outputs.dmg-path }}
-      - name: Cache packages
-        run: ./.ci/create-cache "${CACHE_ID}" ./pkg
+          NOTARIZE_KEY: ${{ steps.secrets.outputs.notarization_key }}
+      - name: Store DMG
+        run: ./.ci/create-cache "${CACHE_ID}" ./dmg
         env:
           CACHE_ID: ${{ needs.info.outputs.macos-cache-id }}
   build-windows:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true' && always()
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true'
     name: Build Windows package
     runs-on: windows-latest
     needs: [info, windows-binary]
@@ -288,14 +411,13 @@ jobs:
           name: windows-unsigned-msi
           path: ./pkg
   sign-windows:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true' && always()
+    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builder' && needs.info.outputs.windows-cache-exists != 'true'
     name: Sign Windows MSI
     needs: [info, build-windows]
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       id-token: write
       contents: write
-      packages: write
     steps:
       - name: Authentication
         id: vault-auth

--- a/.github/workflows/utility-binaries-build.yml
+++ b/.github/workflows/utility-binaries-build.yml
@@ -20,12 +20,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-      - name: Get version
+      - name: Get info
         id: info
-        run: ./.ci/utility-information
-      - name: Build utilities
-        run: make all
-      - name: Publish utilities
-        run: . ./.ci/load-ci.sh && prerelease "${UTILITY_VERSION}" ./bin
+        run: ./.ci/utility-bins-information
+      - name: Build and publish utilities
+        if: ${{ steps.info.outputs.utility-bins-release-exists != 'true' }}
+        run: ./.ci/utility-binaries-prerelease "${UTILITY_VERSION}"
         env:
-          UTILITY_VERSION: ${{ steps.info.outputs.utility-version }}
+          UTILITY_VERSION: ${{ steps.info.outputs.utility-bins-version }}

--- a/.github/workflows/utility-prerelease.yml
+++ b/.github/workflows/utility-prerelease.yml
@@ -9,7 +9,6 @@ jobs:
     name: Build packages
     permissions:
       contents: write
-      packages: write
       id-token: write
     uses: ./.github/workflows/build-utility-packages.yml
     secrets: inherit
@@ -28,11 +27,11 @@ jobs:
         env:
           CACHE_ID: ${{ needs.build-packages.outputs.linux-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Fetch macOS packages
-      #   run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
-      #   env:
-      #     CACHE_ID: ${{ needs.build-packages.outputs.macos-cache-id }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch macOS packages
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.build-packages.outputs.macos-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch windows packages
         run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
         env:

--- a/.github/workflows/utility-prerelease.yml
+++ b/.github/workflows/utility-prerelease.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - 'build-utility-*'
+      - 'build-utility-prerelease-*'
 
 jobs:
   build-packages:

--- a/.github/workflows/utility-release.yml
+++ b/.github/workflows/utility-release.yml
@@ -10,7 +10,6 @@ jobs:
     name: Build packages
     permissions:
       contents: write
-      packages: write
       id-token: write
     uses: ./.github/workflows/build-utility-packages.yml
     secrets: inherit
@@ -20,7 +19,6 @@ jobs:
     runs-on: ['self-hosted', 'ondemand', 'linux', 'type=t3.small']
     permissions:
       contents: read
-      packages: write
       id-token: write
     steps:
       - name: Authentication
@@ -45,11 +43,11 @@ jobs:
         env:
           CACHE_ID: ${{ needs.info.outputs.linux-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Fetch macOS packages
-      #   run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
-      #   env:
-      #     CACHE_ID: ${{ needs.info.outputs.macos-cache-id }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch macOS packages
+        run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
+        env:
+          CACHE_ID: ${{ needs.info.outputs.macos-cache-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch windows packages
         run: ./.ci/restore-cache "${CACHE_ID}" ./pkg
         env:


### PR DESCRIPTION
This enables macOS package builds using the same strategy 
applied to Vagrant packages. Includes some helper script
updates copied over from vagrant-installers and updates
to the utility dev/nightly builds.
