### PR TITLE
Only single product type for Fusion

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -186,17 +186,22 @@ module HashiCorp
         def product_type
           return @product_type if @product_type
 
-          # If the license is standard, the type is player
-          if standard?
-            return @product_type = "player"
-          end
-
+          @logger.debug("determining product type")
           case @product_name.downcase
           when "workstation"
-            @product_type = "ws"
+            # If the license is standard, the type is player
+            if standard?
+              @logger.debug("workstation product with standard license: player")
+              @product_type = "player"
+            else
+              @logger.debug("workstation product with professional license: ws")
+              @product_type = "ws"
+            end
           when "fusion"
+            @logger.debug("fusion product: fusion")
             @product_type = "fusion"
           else
+            @logger.debug("unknown product (#{@product_name}), defaulting: player")
             @product_type = "player"
           end
 

--- a/spec/vagrant-vmware-desktop/driver_spec.rb
+++ b/spec/vagrant-vmware-desktop/driver_spec.rb
@@ -70,8 +70,8 @@ describe HashiCorp::VagrantVMwareDesktop::Driver::Base do
       context "when license is standard" do
         let(:license) { "vl" }
 
-        it "should return the type as 'player'" do
-          expect(instance.product_type).to eq("player")
+        it "should return the type as 'fusion'" do
+          expect(instance.product_type).to eq("fusion")
         end
       end
 


### PR DESCRIPTION
When detecting product type, Fusion does not use player for standard
licenses. Remove license type check when running under Fusion and set
the type only based on the Fusion product.

Fixes #78
