### PR TITLE
Enable pruning globally

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -4,17 +4,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  prune-drafts:
-    if: github.repository == 'hashicorp/vagrant-vmware-desktop-builders'
-    name: Prune stale draft releases
+  prune-builder:
+    name: Prune stale drafts and prereleases
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Prune any drafts older than 20 days
         run: . ./.ci/load-ci.sh && github_draft_release_prune "20"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Only retain last 10 prereleases
+        run: . ./.ci/load-ci.sh && github_release_prune_retain "prerelease" "10"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enables pruning releases from both the public repository
and the private build repository. Impact on the public
repository will be the retention of the last 10 nightly
builds.
