### PR TITLE
Update macOS package naming

### DIFF
--- a/.ci/build-macos-dmg
+++ b/.ci/build-macos-dmg
@@ -24,7 +24,7 @@ if [ -z "${UTILITY_VERSION}" ]; then
 fi
 
 # Properly formatted name for releases
-asset_name="vagrant-vmware-utility_${UTILITY_VERSION}_darwin_amd64.dmg"
+asset_name="vagrant-vmware-utility_${UTILITY_VERSION}_darwin_universal.dmg"
 
 # Check if we have the dmgbuild command available. If not,
 # install it now.

--- a/.ci/utility-macos-rename-release
+++ b/.ci/utility-macos-rename-release
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script is used for updating the macos package from a single
+# universal package to two arch based packages (by making a copy
+# of the file). This is done because the release system only supports
+# darwin packages with "arm64" or "amd64". Once "universal" is supported,
+# this can be removed.
+
+csource="${BASH_SOURCE[0]}"
+while [ -h "$csource" ] ; do csource="$(readlink "$csource")"; done
+root="$( cd -P "$( dirname "$csource" )/../" && pwd )"
+
+. "${root}/.ci/load-ci.sh"
+
+pkg_dir="${1}"
+
+if [ -z "${pkg_dir}" ]; then
+    failure "Directory containing macOS DMG required"
+fi
+if [ ! -d "${pkg_dir}" ]; then
+    failure "Provided path is not a directory (%s)" "${pkg_dir}"
+fi
+
+pushd "${pkg_dir}"
+
+files=( ./*_universal.dmg )
+dmg_path="${files[0]}"
+if [ ! -f "${dmg_path}" ]; then
+    failure "Failed to detect DMG path in '%s' (%s)" "${pkg_dir}" "${dmg_path}"
+fi
+
+base_name="${dmg_path##*/}"
+base_name="${base_name%_universal.dmg}"
+
+cp "${dmg_path}" "./${base_name}_amd64.dmg" ||
+    failure "Unable to create amd64 instance of DMG"
+cp "${dmg_path}" "./${base_name}_arm64.dmg" ||
+    failure "Unable to create arm64 instance of DMG"
+
+rm -f "${dmg_path}"

--- a/.github/workflows/utility-release.yml
+++ b/.github/workflows/utility-release.yml
@@ -61,6 +61,8 @@ jobs:
         env:
           CACHE_ID: ${{ needs.build-packages.outputs.windows-cache-id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update macOS package name
+        run: ./.ci/utility-macos-rename-release ./pkg
       - name: Release Packages
         run: ./.ci/utility-packages-release "${UTILITY_VERSION}" "./pkg"
         env:


### PR DESCRIPTION
Use a `_universal` suffix when building the macOS package. During
the release process, generate valid macOS file names supported by
the release system.
