### PR TITLE
Fix vmexec command formatting

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -1259,7 +1259,7 @@ module HashiCorp
           command_opts = { :notify => [:stdout, :stderr] }
           command_opts[:timeout] = opts[:timeout] if opts[:timeout]
 
-          command = command.dup
+          command = command.dup.map(&:to_s)
           command << command_opts
 
 
@@ -1269,7 +1269,7 @@ module HashiCorp
               if VagrantVMwareDesktop.wsl?
                 r_path = VagrantVMwareDesktop.windows_to_wsl_path(r_path)
               end
-              result = Vagrant::Util::Subprocess.execute(r_path, *command.map(&:to_s))
+              result = Vagrant::Util::Subprocess.execute(r_path, *command)
               if result.exit_code != 0
                 raise Errors::VMExecError,
                   :executable => executable.to_s,

--- a/spec/vagrant-vmware-desktop/driver_spec.rb
+++ b/spec/vagrant-vmware-desktop/driver_spec.rb
@@ -44,6 +44,20 @@ describe HashiCorp::VagrantVMwareDesktop::Driver::Base do
     allow_any_instance_of(HashiCorp::VagrantVMwareDesktop::Errors::Base).to receive(:translate_error)
   end
 
+  describe "#vmexec" do
+    let(:result) { Vagrant::Util::Subprocess::Result.new(0, "", "") }
+
+    it "should cast command arguments to strings" do
+      expect(Vagrant::Util::Subprocess).to receive(:execute).with("command", "1", "2", "three", anything).and_return(result)
+      instance.send(:vmexec, "command", 1, 2, "three")
+    end
+
+    it "should not cast supplied options to string" do
+      expect(Vagrant::Util::Subprocess).to receive(:execute).with("command", "argument", {notify: [:stdout, :stderr]}).and_return(result)
+      instance.send(:vmexec, "command", "argument")
+    end
+  end
+
   describe "#product_type" do
     let(:info_response) do
       utility_response.new(info_response_hash)


### PR DESCRIPTION
The actual command arguments should be mapped to string values. However,
the final argument used in the splat to the `Subprocess#execute` method
will be the options for the execution, which should remain as a `Hash`.
Perform the type casting prior to pushing the options.

Fixes #86
