### PR TITLE
Mount Folders Unknown Options Fix

### DIFF
--- a/lib/vagrant-vmware-desktop/guest_cap/linux/mount_vmware_shared_folder.rb
+++ b/lib/vagrant-vmware-desktop/guest_cap/linux/mount_vmware_shared_folder.rb
@@ -119,7 +119,7 @@ module HashiCorp
               current_mount_point = "#{VAGRANT_ROOT_MOUNT_POINT}/#{uid}-#{gid}"
               hgfs_mount_options = "allow_other,default_permissions,uid=#{uid},gid=#{gid}"
               hgfs_mount_options << ",#{options[:extra]}" if options[:extra]
-              hgfs_mount_options << ",#{options[:mount_options].join(',')}" if options[:mount_options]
+              hgfs_mount_options << ",#{options[:mount_options].join(',')}" if options[:mount_options] && options[:mount_options].length() > 0
               hgfs_mount = "vmhgfs-fuse -o #{hgfs_mount_options} .host:/ '#{current_mount_point}'"
 
               # Allow user to disable unmounting of default vmhgfs-fuse mount point at /mnt/hgfs


### PR DESCRIPTION
This is both a bug report and fix since it was easy enough. The bug happens when trying to run vagrant up using this plugin AND you are mounting folders AND the mount_options is an empty array. The following error gets dumped when the mounting section happens during vagrant up:
<img width="702" alt="image" src="https://github.com/hashicorp/vagrant-vmware-desktop/assets/55092742/a4b6bb52-c414-4934-80b0-cff897b9928c">

My vagrant file by default passes an empty array for mount_options unless something more specific gets specified.

The error seems to be that an extra comma gets appended to the option string passed after `-o`. This trailing comma should not be appended unless there are actual mount_options because it will cause this error. To fix, I just added a quick array length check.

I also noticed this might be a potential issue on line 83 but don't know enough about this codebase or the kernel module.