### PR TITLE
Fix primary disk resize

### DIFF
--- a/lib/vagrant-vmware-desktop/action.rb
+++ b/lib/vagrant-vmware-desktop/action.rb
@@ -361,10 +361,8 @@ module HashiCorp
                 b3.use SetHostname
               end
 
-              Vagrant::Util::Experimental.guard_with(:disks) do
-                b3.use CleanupDisks
-                b3.use Disk
-              end
+              b3.use CleanupDisks
+              b3.use Disk
               b3.use VMXModify
               b3.use PrepareForwardedPortCollisionParams
               b3.use HandleForwardedPortCollisions

--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -1189,6 +1189,32 @@ module HashiCorp
           disk_size
         end
 
+        # @return [Boolean] Instance is a linked clone
+        def is_linked_clone?
+          if @vmsd_path.nil?
+            @vm_dir.children(true).each do |child|
+              if child.basename.to_s.match(/\.vmsd$/)
+                @vmsd_path = child
+              end
+            end
+          end
+
+          return false if @vmsd_path.nil?
+
+          if @is_clone.nil?
+            @is_clone = false
+
+            File.readlines(@vmsd_path).each do |line|
+              if line.start_with?("cloneOf")
+                @is_clone = true
+                break
+              end
+            end
+          end
+
+          @is_clone
+        end
+
         protected
 
         # This reads the latest DHCP lease for a MAC address on the

--- a/lib/vagrant-vmware-desktop/plugin.rb
+++ b/lib/vagrant-vmware-desktop/plugin.rb
@@ -99,26 +99,24 @@ module HashiCorp
           Cap::Provider
         end
 
-        Vagrant::Util::Experimental.guard_with(:disks) do
-          provider_capability(p_name, :set_default_disk_ext) do
-            require File.expand_path("../cap/disk", __FILE__)
-            Cap::Disk
-          end
+        provider_capability(p_name, :set_default_disk_ext) do
+          require File.expand_path("../cap/disk", __FILE__)
+          Cap::Disk
+        end
 
-          provider_capability(p_name, :default_disk_exts) do
-            require File.expand_path("../cap/disk", __FILE__)
-            Cap::Disk
-          end
+        provider_capability(p_name, :default_disk_exts) do
+          require File.expand_path("../cap/disk", __FILE__)
+          Cap::Disk
+        end
 
-          provider_capability(p_name, :configure_disks) do
-            require File.expand_path("../cap/disk", __FILE__)
-            Cap::Disk
-          end
+        provider_capability(p_name, :configure_disks) do
+          require File.expand_path("../cap/disk", __FILE__)
+          Cap::Disk
+        end
 
-          provider_capability(p_name, :cleanup_disks) do
-            require File.expand_path("../cap/disk", __FILE__)
-            Cap::Disk
-          end
+        provider_capability(p_name, :cleanup_disks) do
+          require File.expand_path("../cap/disk", __FILE__)
+          Cap::Disk
         end
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,9 @@ en:
         Configuring network adapters within the VM...
       destroying: |-
         Deleting the VM...
+      disk_not_growing_linked_primary: |-
+        Increasing the size of the primary disk is not allowed for linked
+        clones. Primary disk of the guest remains unchanged.
       disk_not_shrinking: |-
         Shrinking disks is not supported. Not shrinking disk %{path}
       discarding_suspended_state: |-


### PR DESCRIPTION
Fixes the primary disk resizing to handle types other than scsi. If the guest is a linked clone, the resizing of the disk will be ignored and a warning will be emitted (linked disks cannot be resized).

This also removes the experimental guards from the disks feature.

Fixes hashicorp/vagrant#13290
Fixes hashicorp/vagrant#13230