### PR TITLE
Add wait flag for address lookup

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -592,7 +592,7 @@ module HashiCorp
             # is using an old version of VMware.
             begin
               @logger.info("Trying vmrun getGuestIPAddress...")
-              result = vmrun("getGuestIPAddress", host_vmx_path)
+              result = vmrun("getGuestIPAddress", host_vmx_path, "-wait", {timeout: 10})
               result = result.stdout.chomp
 
               # If returned address ends with a ".1" do not accept address

--- a/spec/vagrant-vmware-desktop/driver_spec.rb
+++ b/spec/vagrant-vmware-desktop/driver_spec.rb
@@ -338,7 +338,7 @@ describe HashiCorp::VagrantVMwareDesktop::Driver::Base do
     let(:vmrun_result){ double(stdout: guest_ip) }
     context "with vmrun ip lookup enabled" do
       before do
-        expect(instance).to receive(:vmrun).with("getGuestIPAddress", vmx_file.to_s).and_return(vmrun_result)
+        expect(instance).to receive(:vmrun).with("getGuestIPAddress", vmx_file.to_s, "-wait", {timeout: 10}).and_return(vmrun_result)
       end
 
       it "should return guest IP via vmrun command" do
@@ -385,7 +385,7 @@ describe HashiCorp::VagrantVMwareDesktop::Driver::Base do
 
       before do
         expect(instance).to receive(:read_dhcp_lease).with("vmnet8", mac).and_return(guest_ip)
-        expect(instance).to receive(:vmrun).with("getGuestIPAddress", vmx_file.to_s).and_return(vmrun_result)
+        expect(instance).to receive(:vmrun).with("getGuestIPAddress", vmx_file.to_s, "-wait", {timeout: 10}).and_return(vmrun_result)
       end
 
       it "should discard vmrun IP result and perform DHCP lookup" do


### PR DESCRIPTION
Adds the `-wait` flag when getting the address via guest tools. Can be useful for resolving stuck waits as [described by @eszense](https://github.com/hashicorp/vagrant-vmware-desktop/issues/93#issuecomment-2068043594).
