### PR TITLE
Provide a best effort inspection for cancel errors

### DIFF
--- a/lib/vagrant-vmware-desktop/errors.rb
+++ b/lib/vagrant-vmware-desktop/errors.rb
@@ -263,6 +263,10 @@ module HashiCorp
         error_key(:vmnet_no_ipv6)
       end
 
+      class VMCancelError < Base
+        error_key(:vmcancel_error)
+      end
+
       class VMExecError < Base
         error_key(:vmexec_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -488,6 +488,15 @@ en:
           The VMware product does not support IPv6 in a robust way like other
           Vagrant providers. This is not a bug in Vagrant - the upstream
           provider does not provide robust support for IPv6.
+        vmcancel_error: |-
+          An error occurred causing VMware to cancel the current operation. Details
+          of the error causing the cancelation:
+
+          %{error}
+
+          The full log can be located at:
+
+          %{vmware_log_path}
         vmexec_error: |-
           An error occurred while executing `%{executable}`, a utility for controlling
           VMware machines. The command and output are below:


### PR DESCRIPTION
If a process exits with an error and the output indicates the
operation was canceled, attempt to inspect the vmware log file
to determine the error causing the cancelation. If error information
cannot be extracted, fallback to default behavior.
