### PR TITLE
vagrant up should execute provisioners with 'run' set to 'always' when the VM is running like with Virtualbox/Hyper-V/Docker

### DIFF
--- a/lib/vagrant-vmware-desktop/action.rb
+++ b/lib/vagrant-vmware-desktop/action.rb
@@ -329,7 +329,7 @@ module HashiCorp
 
           b.use Call, Running do |env, b2|
             if env[:result]
-              b2.use MessageAlreadyRunning
+              b2.use action_provision
               next
             end
 


### PR DESCRIPTION
While migrating from Virtualbox to VMWare, I noticed a difference in Vagrant's behavior.
When using Virtualbox and running 'vagrant up' with the VMs already running, Vagrant still executes the "run: 'always" provisioners. However, all the provisioners are skipped when doing the same thing with VMWare.
After some investigation, I noticed that the Virtualbox behavior was added in 2016 in this commit:
https://github.com/hashicorp/vagrant/commit/e42f346b1d5891b5bd3651564894b95ed3b8b6cc
Issue link: https://github.com/hashicorp/vagrant/issues/4421

The commit added this behavior for the Virtualbox/Hyper-V/Docker providers. However, it appears that the fix was never ported to the VMWare plugin which results in inconsistent behavior.

I validated that with this change, 'vagrant up' runs the 'always' provisioners when the VMs are running.
I also validated that passing the --no-provision parameter skips the provisioners.

This ticket fixes the issue: https://github.com/hashicorp/vagrant-vmware-desktop/issues/140