### PR TITLE
vagrant snapshot restore times out due to hard coded 45 seconds timeout

### DIFF
--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -33,6 +33,10 @@ module HashiCorp
         # Number of bytes in disk sector
         SECTOR_TO_BYTES = 512.freeze
 
+        # Number of seconds to allow the vmrun start command
+        # to complete
+        VMRUN_START_TIMEOUT = 300.freeze
+
         # Vagrant utility version requirement which must be satisfied to properly
         # work with this version of the plugin. This should be used when new API
         # end points are added to the utility to ensure expected functionality.
@@ -944,10 +948,10 @@ module HashiCorp
         # This will start the VMware machine.
         def start(gui=false)
           gui_arg = gui ? "gui" : "nogui"
-          vmrun("start", host_vmx_path, gui_arg, retryable: true, timeout: 300)
+          vmrun("start", host_vmx_path, gui_arg, retryable: true, timeout: VMRUN_START_TIMEOUT)
         rescue Vagrant::Util::Subprocess::TimeoutExceeded
           # Sometimes vmrun just hangs. We give it a generous timeout
-          # of 5 minutes, and then throw this.
+          # and then throw this.
           raise Errors::StartTimeout
         end
 

--- a/lib/vagrant-vmware-desktop/driver/base.rb
+++ b/lib/vagrant-vmware-desktop/driver/base.rb
@@ -944,10 +944,10 @@ module HashiCorp
         # This will start the VMware machine.
         def start(gui=false)
           gui_arg = gui ? "gui" : "nogui"
-          vmrun("start", host_vmx_path, gui_arg, retryable: true, timeout: 45)
+          vmrun("start", host_vmx_path, gui_arg, retryable: true, timeout: 300)
         rescue Vagrant::Util::Subprocess::TimeoutExceeded
           # Sometimes vmrun just hangs. We give it a generous timeout
-          # of 45 seconds, and then throw this.
+          # of 5 minutes, and then throw this.
           raise Errors::StartTimeout
         end
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/hashicorp/vagrant-vmware-desktop/issues/149

When executing a vagrant snapshot restore with VMWare, there is a timeout of 45 seconds to start the VM.
VMWare restores the snapshot while starting the VM which can easily take more than 45 seconds.
This results in the following error:
```
Vagrant timed out while trying to start the VMware machine. This
error is caused by VMware never successfully starting the machine.
This can often be fixed by simply retrying. If the error persists,
please verify that VMware is functional. This is not a Vagrant
issue.
```
There is no such timeout in the Vagrant's Virtualbox plugin. Since the comment in the code mentions that this timeout was included since vmrun can hang, I chose to keep it, but to increase it significantly enough (5 minutes) to prevent it from timing out in normal scenarios like a snapshot restore.

We could also remove it to remain coherent with Vagrant's Virtualbox plugin, but this seems safer.