### PR TITLE
Primary disk checks and cleanup

### DIFF
--- a/lib/vagrant-vmware-desktop.rb
+++ b/lib/vagrant-vmware-desktop.rb
@@ -19,11 +19,15 @@ module HashiCorp
       "vagrant-vmware-workstation"
     ].map(&:freeze).freeze
 
-    lib_path = Pathname.new(File.expand_path("../vagrant-vmware-desktop", __FILE__))
-    autoload :Action, lib_path.join("action")
-    autoload :Driver, lib_path.join("driver")
-    autoload :Errors, lib_path.join("errors")
-    autoload :SudoHelper, lib_path.join("sudo_helper")
+    autoload :Action, "vagrant-vmware-desktop/action"
+    autoload :Cap, "vagrant-vmware-desktop/cap"
+    autoload :CheckpointClient, "vagrant-vmware-desktop/checkpoint_client"
+    autoload :Config, "vagrant-vmware-desktop/config"
+    autoload :Driver, "vagrant-vmware-desktop/driver"
+    autoload :Errors, "vagrant-vmware-desktop/errors"
+    autoload :Provider, "vagrant-vmware-desktop/provider"
+    autoload :SetupPlugin, "vagrant-vmware-desktop/setup_plugin"
+    autoload :SyncedFolder, "vagrant-vmware-desktop/synced_folder"
 
     # This initializes the i18n load path so that the plugin-specific
     # translations work.

--- a/lib/vagrant-vmware-desktop/cap.rb
+++ b/lib/vagrant-vmware-desktop/cap.rb
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module HashiCorp
+  module VagrantVMwareDesktop
+    module Cap
+      autoload :Disk, "vagrant-vmware-desktop/cap/disk"
+      autoload :Provider, "vagrant-vmware-desktop/cap/provider"
+      autoload :Snapshot, "vagrant-vmware-desktop/cap/snapshot"
+    end
+  end
+end

--- a/lib/vagrant-vmware-desktop/cap/disk.rb
+++ b/lib/vagrant-vmware-desktop/cap/disk.rb
@@ -114,9 +114,12 @@ module HashiCorp
           if disk.primary
             PRIMARY_DISK_SLOTS.each do |primary_slot|
               disk_info = all_disks[primary_slot]
-              @@logger.debug("disk info for primary slot #{primary_slot} - #{disk_info}")
-              return disk_info if !disk_info.nil? && disk_info["present"].to_s.upcase == "TRUE"
+              if disk_info
+                @@logger.debug("disk info for primary slot #{primary_slot} - #{disk_info}")
+                return disk_info if disk_info["present"].to_s.upcase == "TRUE"
+              end
             end
+
             nil
           else
             if disk.type == :dvd
@@ -143,6 +146,8 @@ module HashiCorp
           current_disk = get_disk(disk, attached_disks)
 
           if current_disk.nil?
+            raise Errors::DiskPrimaryMissing if disk.primary
+
             disk_path = create_disk(machine, disk, attached_disks)
           else
             # If the path matches the disk name + some extra characters then

--- a/lib/vagrant-vmware-desktop/driver.rb
+++ b/lib/vagrant-vmware-desktop/driver.rb
@@ -1,13 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-require "vagrant/util/platform"
-
-require "vagrant-vmware-desktop/driver/base"
-
 module HashiCorp
   module VagrantVMwareDesktop
     module Driver
+      autoload :Base, "vagrant-vmware-desktop/driver/base"
+
       # This returns a new driver for the given VM directory, using the
       # proper underlying platform driver.
       def self.create(vm_dir, config)

--- a/lib/vagrant-vmware-desktop/errors.rb
+++ b/lib/vagrant-vmware-desktop/errors.rb
@@ -47,6 +47,10 @@ module HashiCorp
         error_key(:disk_not_resized_snapshot)
       end
 
+      class DiskPrimaryMissing < Base
+        error_key(:disk_primary_missing)
+      end
+
       class MissingNATDevice < Base
         error_key(:missing_nat_device)
       end

--- a/lib/vagrant-vmware-desktop/guest_cap.rb
+++ b/lib/vagrant-vmware-desktop/guest_cap.rb
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module HashiCorp
+  module VagrantVMwareDesktop
+    module GuestCap
+      autoload :Linux, "vagrant-vmware-desktop/guest_cap/linux"
+    end
+  end
+end

--- a/lib/vagrant-vmware-desktop/guest_cap/linux.rb
+++ b/lib/vagrant-vmware-desktop/guest_cap/linux.rb
@@ -1,0 +1,13 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module HashiCorp
+  module VagrantVMwareDesktop
+    module GuestCap
+      module Linux
+        autoload :VerifyVMwareHGFS, "vagrant-vmware-desktop/guest_cap/linux/verify_vmware_hgfs"
+        autoload :MountVMwareSharedFolder, "vagrant-vmware-desktop/guest_cap/linux/mount_vmware_shared_folder"
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -192,6 +192,8 @@ en:
           disk please remove snapshots associated with the VM.
 
           Path: %{path}
+        disk_primary_missing: |-
+          Failed to locate the primary disk for the guest.
         destroy_invalid_state: |-
           The VMware machine cannot be destroyed beacuse it is still
           running. Please make sure the machine is properly halted before

--- a/spec/spec_base.rb
+++ b/spec/spec_base.rb
@@ -36,3 +36,4 @@ I18n.load_path << File.expand_path("../../locales/en.yml", __FILE__)
 I18n.reload!
 
 require "vagrant-vmware-desktop"
+HashiCorp::VagrantVMwareDesktop.init_i18n


### PR DESCRIPTION
This extends #134 PR to add test coverage, force error when primary is not properly located, and includes some loading cleanup.
