### PR TITLE
Default to professional license when license data is empty

### DIFF
--- a/go_src/vagrant-vmware-utility/driver/core.go
+++ b/go_src/vagrant-vmware-utility/driver/core.go
@@ -36,6 +36,13 @@ func (v *VmwareInfo) IsProfessional() bool {
 		return false
 	}
 
+	// Empty value may be produced when using the license
+	// generated for free fusion/workstation. If the license
+	// content is empty, just assume it's professional
+	if v.License == "" {
+		return true
+	}
+
 	// Now we need to check if we are using a product that
 	// is a professional version. These include Workstation
 	// and Fusion (but not player)


### PR DESCRIPTION
Reports of the new free licenses show the license check produces
empty content. If empty content is encountered, just default to
marking the installation as professional.

Fixes #102
Fixes #91
