### PR TITLE
Update multiple lease entry handling

### DIFF
--- a/lib/vagrant-vmware-desktop/action.rb
+++ b/lib/vagrant-vmware-desktop/action.rb
@@ -16,6 +16,7 @@ module HashiCorp
       include Vagrant::Action::Builtin
       include Vagrant::Action::General
 
+      autoload :BaseMacConfigWarning, "vagrant-vmware-desktop/action/base_mac_config_warning"
       autoload :BaseMacToIp, "vagrant-vmware-desktop/action/base_mac_to_ip"
       autoload :Boot, "vagrant-vmware-desktop/action/boot"
       autoload :CheckExistingNetwork, "vagrant-vmware-desktop/action/check_existing_network"
@@ -432,6 +433,8 @@ module HashiCorp
               b2.use Import
               b2.use SetDisplayName
             end
+
+            b2.use BaseMacConfigWarning
 
             b2.use action_start
           end

--- a/lib/vagrant-vmware-desktop/action/base_mac_config_warning.rb
+++ b/lib/vagrant-vmware-desktop/action/base_mac_config_warning.rb
@@ -1,0 +1,72 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module HashiCorp
+  module VagrantVMwareDesktop
+    module Action
+      # This inspects the Vagrantfile provided by the
+      # box (if one was provided) and checks if it
+      # set the `base_mac` value. If it did, a warning
+      # will be generated to the user.
+      #
+      # NOTE: This action is merely a "best effort" at
+      # providing the warning. It is using non-public
+      # Vagrant internals to inspect box Vagrantfile.
+      # As such, any errors encountered will be ignored
+      # with only a debug log.
+      class BaseMacConfigWarning
+        include Common
+
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new("hashicorp::provider::vmware::basemacwarning")
+        end
+
+        def call(env)
+          catch(:complete) do
+            begin
+              # Attempt to extract the vagrantfile loader
+              loader = env[:machine].vagrantfile.instance_variable_get(:@loader)
+              if !loader
+                @logger.debug("base_mac check in box vagrantfile failed - cannot access loader")
+                throw :complete
+              end
+
+              # Attempt to get the Vagrantfile source for the box
+              # provided Vagrantfile
+              source = loader.instance_variable_get(:@sources)&.keys&.last
+              if !source
+                @logger.debug("base_mac check in box vagrantfile failed - cannot get box source")
+                throw :complete
+              end
+
+              begin
+                # Attempt to load the partial config
+                partial = loader.partial_load(source)
+
+                # Only proceed to display warning if the base_mac value
+                # in the partial load matches the base_mac in the final
+                # config
+                throw :complete if partial.vm.base_mac != env[:machine].config.vm.base_mac
+
+                # Display the warning message
+                env[:ui].warn(
+                  I18n.t(
+                    "hashicorp.vagrant_vmware_desktop.box_base_mac_warning",
+                    base_mac: env[:machine].config.vm.base_mac
+                  )
+                )
+              rescue KeyError => err
+                @logger.debug("base_mac check in box vagrantfile failed - partial load failure #{err.class}: #{err}")
+              end
+            rescue => err
+              @logger.debug("base_mac check in box vagrantfile failed - #{err.class}: #{err}")
+            end
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,6 +4,20 @@
 en:
   hashicorp:
     vagrant_vmware_desktop:
+      box_base_mac_warning: |-
+        Detected guest `base_mac` value set within the Vagrantfile
+        included with this box. Having the `base_mac` value set
+        for VMware guests may cause issues properly identifying
+        the guest IP address due to MAC collisions.
+
+          Current value: %{base_mac}
+
+        To disable the `base_mac` value so it will be randomly
+        generated, set the value to nil in the Vagrantfile:
+
+          config.vm.base_mac = nil
+
+        https://www.vagrantup.com/docs/vagrantfile/machine_settings#config-vm-base_mac
       already_running: |-
         Machine is already running.
       booted_and_ready: |-


### PR DESCRIPTION
When multiple lease entries are encountered for a MAC address, use the most recently generated entry _if_ the entry hostname's match. If the hostnames of the entries do not match, the MAC address is marked as invalid and none will be used.

Because this problem generally originates when the `base_mac` value is set within a Vagrantfile provided inside the box, a check is added during the guest creation for the `base_mac` being set. If it is detected, a warning is generated with information of the problem it may cause, and how it can be fixed locally. 

Fixes: #129 