### PR TITLE
Snapshot management should be the same as Virtualbox

### DIFF
--- a/lib/vagrant-vmware-desktop/cap/snapshot.rb
+++ b/lib/vagrant-vmware-desktop/cap/snapshot.rb
@@ -13,7 +13,7 @@ module HashiCorp
         # @param [Vagrant::Machine] machine - the current machine
         # @return [List<String>] - snapshot names
         def self.snapshot_list(machine)
-          machine.provider.driver.snapshot_tree
+          machine.provider.driver.snapshot_list
         end
 
         # Delete all snapshots for the machine


### PR DESCRIPTION
This PR fixes this issue: https://github.com/hashicorp/vagrant/issues/13694

The snapshot management in the Vagrant VMWare plugin is different than the Virtualbox implementation.
In the Virtualbox implementation, doing "vagrant snapshot list" returns the list of snapshots as follows:

```
$ vagrant snapshot list
==> vm1:
snapshot1
snapshot2
snapshot3
==> vm2:
snapshot2
snapshot3
```

You can then restore the snapshots based on the unique name for the complete lab or per VM.
In the Vagrant VMWare plugin, the "vagrant snapshot list" returns a tree like list instead:

```
$ vagrant snapshot list
==> vm1:
snapshot1
snapshot1/snapshot2
snapshot1/snapshot2/snapshot3
==> vm2:
snapshot2
snapshot2/snapshot3
```

You must then pass the "path" in the vagrant snapshot restore command instead of only passing the snapshot name.
Trying to restore "snapshot2" for example would result in this error:

```
The snapshot name `snapshot2` was not found for the
virtual machine `vm1`.
```

To restore the snapshot, you need to pass the full path like "vagrant snapshot restore snapshot1/snapshot2".
However, this doesn't work in the example above since the path to "snapshot2" is different on both VMs. So it is not possible to restore this snapshot in one command.

Tests:
1. Validate that 'vagrant snapshot list' returns the snapshots without the tree structure like its done for Virtualbox.
2. Validate that 'vagrant snapshot restore' can restore a nested snapshot with only the snapshot name (ex: "snapshot2" in the example above).
3. Validate that 'vagrant snapshot restore' can restore a nested snapshot on multiple VMs even if the path to the snapshot is different on the VMs (ex: "snapshot3" in the example above).